### PR TITLE
Add a requires section to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
     "keywords": ["facebook", "xhp", "hhvm", "hack"],
     "homepage": "https://github.com/facebook/xhp-lib",
     "license": ["PHP-3.01",  "Zend-2.0"],
+    "require": {
+        "ext-xhp": "*"
+    },
     "autoload": {
         "classmap": [
             "src/"


### PR DESCRIPTION
HHVM reports itself as having an extension named "xhp" (``hhvm --php -r "var_dump(extension_loaded('xhp'));"`` => ``bool(true)``), so tell composer to check for that when trying to install this package. If this repo ever gets hackified, then this can change to ``hhvm`` instead of ``ext-xhp``.