### PR TITLE
Changed ext-xhp requirement to hhvm, fixes #102

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/facebook/xhp-lib",
     "license": ["BSD-3-Clause"],
     "require": {
-        "ext-xhp": "*"
+        "hhvm": "*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Since hack is required, hhvm should be required, not the xhp php extension