### PR TITLE
Add Support for Awaitable XHP

### DIFF
--- a/src/core.php
+++ b/src/core.php
@@ -495,10 +495,10 @@ abstract class :x:composable-element extends :x:base {
     $flushWaitHandles = Vector{};
     do {
       if ($childWaitHandles || $flushWaitHandles) {
-        list($awaitedChildren, $_) = await GenUtils::genList(
-          GenUtils::genIntMap($childWaitHandles),
-          GenUtils::genVector($flushWaitHandles),
-        );
+        list($awaitedChildren, $_) = await GenArrayWaitHandle::create(array(
+          GenMapWaitHandle::create($childWaitHandles),
+          GenVectorWaitHandle::create($flushWaitHandles),
+        ));
         if ($awaitedChildren) {
           foreach ($awaitedChildren as $i => $awaitedChild) {
             $this->children->set($i, $awaitedChild);
@@ -546,7 +546,7 @@ abstract class :x:composable-element extends :x:base {
     } while ($childWaitHandles);
 
     if ($flushWaitHandles) {
-      await GenUtils::genVector($flushWaitHandles);
+      await GenVectorWaitHandle::create($flushWaitHandles);
     }
   }
 

--- a/src/core.php
+++ b/src/core.php
@@ -355,11 +355,7 @@ abstract class :x:composable-element extends :x:base {
     if (!self::isAttributeSpecial($attr)) {
       $value = $this->validateAttributeValue($attr, $value);
     } else {
-      if ($attr == 'data-meta' && is_array($value)) {
-        $value = JS::registerData($this, $value);
-      } else {
-        $value = (string)$value;
-      }
+      $value = (string)$value;
     }
     $this->attributes->set($attr, $value);
     return $this;

--- a/src/core.php
+++ b/src/core.php
@@ -1249,9 +1249,9 @@ interface XHPUnsafeRenderable extends XHPChild {
 /**
  * INCREDIBLY AWESOME: Specify an element as awaitable on render.
  *
- * This allows you to use generators inside your XHP objects. For
- * instance, you could fetch data inside your XHP elements using await and
- * the calls to the DB would be batched together when the element is rendered.
+ * This allows you to use await inside your XHP objects. For instance, you could
+ * fetch data inside your XHP elements using await and the calls to the DB would
+ * be batched together when the element is rendered.
  */
 interface XHPAwaitable {
   // protected function asyncRender(): Awaitable<XHPRoot>


### PR DESCRIPTION
Adds support for generators inside XHP rendering. This makes one very important change to basic XHP principles, and that is that the rendering order can no longer be guaranteed. Previously, XHP would follow a breadth-first rendering from `:x:element` to `:x:primitive` (concurrently), but with this change, XHP will now render depth-first in search of `WaitHandle`s, batching together as many as it can. Additionally, all `:x:elements` will be rendered before the `:x:primitive` pass will begin. In theory this should have no affect because XHP does not store or encourage storing of references to other XHP elements (besides the parent, which still will be guaranteed to be rendered first). However, it is still possible to manually keep references and a variable rendering order has the potential to affect code in unpredictable ways.

In terms of implementation, I wanted to just have `render()` without the need for `genRender()`, then an interface would be all that was needed, but the return type of `render()` would need to be different in each case. I could get away without using the `XHPAwaitable` interface and instead check for the `XHPGenerator` trait using `class_uses()`, but this doesn’t check parent traits, so I would have to loop over each element’s inheritance chain and that felt very ugly to me.

Also fixed some 80 cols stuff cause I took this from my personal project and I'd made those changes awhile ago.

fixes #93 