### PR TITLE
Alias dev-hack to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,11 @@
     "require-dev": {
         "phpunit/phpunit": "4.5.*"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-hack": "2.x-dev"
+        }
+    },
     "autoload": {
         "classmap": [
             "src/"


### PR DESCRIPTION
As dev-hack's going to be turning into 2.x, would be nice to be able to use "~2" as a version requirement already. This basically has composer treat the hack branch as if it were name 2 instead.