### PR TITLE
Enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: php
 
-php:
-  - hhvm
-  - hhvm-nightly
+php: hhvm
 
 before_script:
   - composer self-update
   - composer install
 
-script:
-  - vendor/bin/phpunit tests/
+script: vendor/bin/phpunit tests/
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - hhvm
+  - hhvm-nightly
+
+before_script:
+  - composer self-update
+  - composer install
+
+script:
+  - vendor/bin/phpunit tests/
+
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#hhvm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,3 @@ before_script:
   - composer install
 
 script: vendor/bin/phpunit tests/
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#hhvm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: php
 
-php: hhvm
+php:
+  - hhvm
+  - hhvm-nightly
+
+# Allow hhvm-nightly to fail until https://github.com/facebook/hhvm/issues/4934
+# is fixed
+matrix:
+  allow_failures:
+    - php: hhvm-nightly
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Requires someone with the right permissions on the repo to add it to travis-ci.org as well.

Once facebook/hhvm#4934 is fixed, just remove the `matrix` section to have failures on hhvm-nightly cause the build to fail.

Example run: https://travis-ci.org/simonwelsh/xhp/builds/53095054