### PR TITLE
Split out attribute declaration knowledge to new ReflectionXHPAttribute class

### DIFF
--- a/src/core/ReflectionXHPAttribute.php
+++ b/src/core/ReflectionXHPAttribute.php
@@ -1,0 +1,116 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+enum XHPAttributeType: int {
+  TYPE_STRING   = 1;
+  TYPE_BOOL     = 2;
+  TYPE_INTEGER  = 3;
+  TYPE_ARRAY    = 4;
+  TYPE_OBJECT   = 5;
+  TYPE_VAR      = 6;
+  TYPE_ENUM     = 7;
+  TYPE_FLOAT    = 8;
+}
+
+class ReflectionXHPAttribute {
+  private XHPAttributeType $type;
+  /*
+   * OBJECT: string (class name)
+   * ENUM: array<string> (enum values)
+   * ARRAY: Array decl
+   */
+  private mixed $extraType;
+  private mixed $defaultValue;
+  private bool $required;
+
+  private static ImmSet<string> $specialAttributes = ImmSet {
+    'data',
+    'aria',
+  };
+
+  public function __construct(
+    private string $name,
+    array<int, mixed> $decl,
+  ) {
+    $this->type = XHPAttributeType::assert($decl[0]);
+    $this->extraType = $decl[1];
+    $this->defaultValue = $decl[2];
+    $this->required = (bool) $decl[3];
+  }
+
+  public function getName(): string {
+    return $this->name;
+  }
+
+  public function getValueType(): XHPAttributeType {
+    return $this->type;
+  }
+
+  public function isRequired(): bool {
+    return $this->required;
+  }
+
+  public function hasDefaultValue(): bool {
+    return $this->defaultValue !== null;
+  }
+
+  public function getDefaultValue(): mixed {
+    return $this->defaultValue;
+  }
+
+  <<__Memoize>>
+  public function getValueClass(): string {
+    $t = $this->getValueType();
+    invariant(
+      $this->getValueType() === XHPAttributeType::TYPE_OBJECT,
+      'Tried to get value class for attribute %s of type %s - needed '.
+      'OBJECT',
+      $this->getName(),
+      XHPAttributeType::getNames()[$this->getValueType()],
+    );
+    $v = $this->extraType;
+    invariant(
+      is_string($v),
+      'Class name for attribute %s is not a string',
+      $this->getName()
+    );
+    return $v;
+  }
+
+  <<__Memoize>>
+  public function getEnumValues(): Set<string> {
+    $t = $this->getValueType();
+    invariant(
+      $this->getValueType() === XHPAttributeType::TYPE_ENUM,
+      'Tried to get enum values for attribute %s of type %s - needed '.
+      'ENUM',
+      $this->getName(),
+      XHPAttributeType::getNames()[$this->getValueType()],
+    );
+    $v = $this->extraType;
+    invariant(
+      is_array($v),
+      'Class name for attribute %s is not a string',
+      $this->getName()
+    );
+    return new Set($v);
+  }
+
+  /**
+   * Returns true if the attribute is a data- or aria- attribute.
+   */
+  <<__Memoize>>
+  public static function IsSpecial(string $attr): bool {
+    return strlen($attr) >= 6
+      && $attr[4] === '-'
+      && self::$specialAttributes->contains(substr($attr, 0, 4));
+  }
+}


### PR DESCRIPTION
- stricter typing
- fewer array casts
- no isset
- added safety checks

This is part of #113 