### PR TITLE
Correct case of assertSame

### DIFF
--- a/tests/AttributesCoercionModeTest.php
+++ b/tests/AttributesCoercionModeTest.php
@@ -39,7 +39,7 @@ class AttributesCoercionModeTest extends PHPUnit_Framework_TestCase {
     $this->assertSame(3, $x->:myint);
     $this->assertSame(1.23, $x->:myfloat);
     $this->assertSame('foo', $x->:mystring);
-    $this->assertsame(true, $x->:mybool);
+    $this->assertSame(true, $x->:mybool);
   }
 
   /**


### PR DESCRIPTION
Found this since I've got [this hhi file](https://git.simon.geek.nz/91-carriage/xhp-foundation/blob/master/tests/definitions.hhi) so that I can have everything in xhp-foundation as strict.