### PR TITLE
Add Unresolved attribute

### DIFF
--- a/src/html/Element.php
+++ b/src/html/Element.php
@@ -41,6 +41,7 @@ abstract class :xhp:html-element extends :x:primitive {
     Stringish tabindex,
     Stringish title,
     enum {'yes', 'no'} translate,
+    bool unresolved,
 
     // Javascript events
     Stringish onabort,


### PR DESCRIPTION
Added a missing HTML5 attribute 'unresolved' related to Custom Elements.