### PR TITLE
Automatically call transferAttributes as needed.

### DIFF
--- a/autoload-map.php
+++ b/autoload-map.php
@@ -11,6 +11,7 @@ namespace Facebook\XHPLib\Autoloader;
 
 function autoload($class): bool {
   $classmap = Map {
+    'HasXHPBaseHTMLHelpers' => '/src/html/HasXHPBaseHTMLHelpers.php',
     'HasXHPHelpers' => '/src/html/XHPHelpers.php',
     'ReflectionXHPAttribute' => '/src/core/ReflectionXHPAttribute.php',
     'ReflectionXHPChildrenDeclaration' => '/src/core/ReflectionXHPChildrenDeclaration.php',
@@ -24,12 +25,14 @@ function autoload($class): bool {
     'XHPAttributeRequiredException' => '/src/exceptions/AttributeRequiredException.php',
     'XHPAttributeType' => '/src/core/ReflectionXHPAttribute.php',
     'XHPAwaitable' => '/src/core/XHPAwaitable.php',
+    'XHPBaseHTMLHelpers' => '/src/html/XHPBaseHTMLHelpers.php',
     'XHPChildrenConstraintType' => '/src/core/ReflectionXHPChildrenDeclaration.php',
     'XHPChildrenDeclarationType' => '/src/core/ReflectionXHPChildrenDeclaration.php',
     'XHPChildrenExpressionType' => '/src/core/ReflectionXHPChildrenDeclaration.php',
     'XHPClassException' => '/src/exceptions/ClassException.php',
     'XHPCoreRenderException' => '/src/exceptions/CoreRenderException.php',
     'XHPException' => '/src/exceptions/Exception.php',
+    'XHPHasTransferAttributes' => '/src/core/XHPHasTransferAttributes.php',
     'XHPHelpers' => '/src/html/XHPHelpers.php',
     'XHPInvalidArrayAttributeException' => '/src/exceptions/InvalidArrayAttributeException.php',
     'XHPInvalidArrayKeyAttributeException' => '/src/exceptions/InvalidArrayKeyAttributeException.php',

--- a/src/core/Element.php
+++ b/src/core/Element.php
@@ -47,6 +47,9 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
       }
       assert($composed instanceof :x:element);
       $composed->__transferContext($that->getAllContexts());
+      if ($that instanceof XHPHasTransferAttributes) {
+        $that->transferAttributesToRenderedRoot($composed);
+      }
       $that = $composed;
     } while ($composed instanceof :x:element);
 
@@ -54,6 +57,7 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
       // render() must always (eventually) return :x:primitive
       throw new XHPCoreRenderException($this, $that);
     }
+
 
     return $composed;
   }

--- a/src/core/Element.php
+++ b/src/core/Element.php
@@ -58,7 +58,6 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
       throw new XHPCoreRenderException($this, $that);
     }
 
-
     return $composed;
   }
 }

--- a/src/core/XHPHasTransferAttributes.php
+++ b/src/core/XHPHasTransferAttributes.php
@@ -1,0 +1,22 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * Indicates that any attributes set on an element should be transferred to the
+ * element returned from ::render() or ::asyncRender(). This is automatically
+ * invoked by :x:element.
+ */
+interface XHPHasTransferAttributes {
+  require extends :x:element;
+  public function transferAttributesToRenderedRoot(
+    :x:composable-element $root,
+  ): void;
+}

--- a/src/html/Element.php
+++ b/src/html/Element.php
@@ -16,8 +16,7 @@
  * own elements.
  */
 abstract class :xhp:html-element extends :x:primitive {
-
-  use XHPHelpers;
+  use XHPBaseHTMLHelpers;
 
   attribute
     // Global HTML attributes

--- a/src/html/HasXHPBaseHTMLHelpers.php
+++ b/src/html/HasXHPBaseHTMLHelpers.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+interface HasXHPBaseHTMLHelpers {
+  require extends :x:composable-element;
+
+  public function addClass(string $class): this;
+  public function conditionClass(bool $cond, string $class): this;
+  public function requireUniqueID(): string;
+  public function getID(): string;
+}

--- a/src/html/XHPBaseHTMLHelpers.php
+++ b/src/html/XHPBaseHTMLHelpers.php
@@ -10,7 +10,7 @@
  *
  */
 
-trait XHPBaseHTMLHelpers implements HasXHPBaseHTMLHelpers{
+trait XHPBaseHTMLHelpers implements HasXHPBaseHTMLHelpers {
   require extends :x:composable-element;
 
   /*

--- a/src/html/XHPBaseHTMLHelpers.php
+++ b/src/html/XHPBaseHTMLHelpers.php
@@ -1,0 +1,68 @@
+<?hh // strict
+
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+trait XHPBaseHTMLHelpers implements HasXHPBaseHTMLHelpers{
+  require extends :x:composable-element;
+
+  /*
+   * Appends a string to the "class" attribute (space separated).
+   */
+  public function addClass(string $class): this {
+    try {
+      $current_class = /* UNSAFE_EXPR */ $this->:class;
+      return $this->setAttribute('class', trim($current_class.' '.$class));
+    } catch (XHPInvalidAttributeException $error) {
+      throw new XHPException(
+        'You are trying to add an HTML class to a(n) '.
+        :xhp::class2element(static::class).' element, but it does not support '.
+        'the "class" attribute. The best way to do this is to inherit '.
+        'the HTML attributes from the element your component will render into.',
+      );
+    }
+  }
+
+  /*
+   * Conditionally adds a class to the "class" attribute.
+   */
+  public function conditionClass(bool $cond, string $class): this {
+    return $cond ? $this->addClass($class) : $this;
+  }
+
+  /*
+   * Generates a unique ID (and sets it) on the "id" attribute. A unique ID
+   * will only be generated if one has not already been set.
+   */
+  public function requireUniqueID(): string {
+    $id = /* UNSAFE_EXPR */ $this->:id;
+    if ($id === null || $id === '') {
+      try {
+        $this->setAttribute('id', $id = substr(md5(mt_rand(0, 100000)), 0, 10));
+      } catch (XHPInvalidAttributeException $error) {
+        throw new XHPException(
+          'You are trying to add an HTML id to a(n) '.
+          :xhp::class2element(static::class).' element, but it does not '.
+          'support the "id" attribute. The best way to do this is to inherit '.
+          'the HTML attributes from the element your component will render '.
+          'into.',
+        );
+      }
+    }
+    return (string)$id;
+  }
+
+  /*
+   * Fetches the "id" attribute, will generate a unique value if not set.
+   */
+  final public function getID(): string {
+    return $this->requireUniqueID();
+  }
+}

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -175,8 +175,10 @@ trait XHPHelpers implements HasXHPHelpers {
       $thisValue = array_key_exists($attr, $attributes)
         ? (string) $attributes[$attr]
         : '';
-      if ($rootValue !== '' && $thisValue !== '') {
-        $root->setAttribute($attr, $rootValue.' '.$thisValue);
+      if ($rootValue !== '') {
+        if ($thisValue !== '') {
+          $root->setAttribute($attr, $rootValue.' '.$thisValue);
+        }
         $this->removeAttribute($attr);
       }
     }

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -134,7 +134,7 @@ trait XHPHelpers implements HasXHPHelpers {
     }
   }
 
-  protected function getAttributesThatAppendValuesOnTransfer(): ImmSet<string> {
+  protected function getAttributeNamesThatAppendValuesOnTransfer(): ImmSet<string> {
     return ImmSet { 'class' };
   }
 
@@ -170,16 +170,19 @@ trait XHPHelpers implements HasXHPHelpers {
 
     // We want to append classes to the root node, instead of replace them,
     // so do this attribute manually and then remove it.
-    foreach ($this->getAttributesThatAppendValuesOnTransfer() as $attr) {
-      $rootValue = (string) $root->getAttribute($attr);
-      $thisValue = array_key_exists($attr, $attributes)
-        ? (string) $attributes[$attr]
-        : '';
-      if ($rootValue !== '') {
-        if ($thisValue !== '') {
-          $root->setAttribute($attr, $rootValue.' '.$thisValue);
+    foreach ($this->getAttributeNamesThatAppendValuesOnTransfer() as $attr) {
+      if (array_key_exists($attr, $attributes)) {
+        $rootAttributes = $root->getAttributes();
+        if (
+          array_key_exists($attr, $rootAttributes)
+          && ($rootValue = (string) $rootAttributes[$attr]) !== ''
+        ) {
+          $thisValue = (string) $attributes[$attr];
+          if ($thisValue !== '') {
+            $root->setAttribute($attr, $rootValue.' '.$thisValue);
+          }
+          $this->removeAttribute($attr);
         }
-        $this->removeAttribute($attr);
       }
     }
 

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -141,8 +141,7 @@ trait XHPHelpers implements HasXHPHelpers {
       if (!($root instanceof HasXHPHelpers)) {
         throw new XHPClassException(
           $this,
-          'compose() must return an :xhp:html-element or :bootstrap:base '.
-          'instance.'
+          'render() must return an object using the XHPHelpers trait.'
         );
       }
 

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -134,6 +134,10 @@ trait XHPHelpers implements HasXHPHelpers {
     }
   }
 
+  protected function getAttributesThatAppendValuesOnTransfer(): ImmSet<string> {
+    return ImmSet { 'class' };
+  }
+
   final public function transferAttributesToRenderedRoot(
     :x:composable-element $root,
   ): void {
@@ -166,9 +170,15 @@ trait XHPHelpers implements HasXHPHelpers {
 
     // We want to append classes to the root node, instead of replace them,
     // so do this attribute manually and then remove it.
-    if (array_key_exists('class', $attributes) && $attributes['class']) {
-      $root->addClass((string) $attributes['class']);
-      $this->removeAttribute('class');
+    foreach ($this->getAttributesThatAppendValuesOnTransfer() as $attr) {
+      $rootValue = (string) $root->getAttribute($attr);
+      $thisValue = array_key_exists($attr, $attributes)
+        ? (string) $attributes[$attr]
+        : '';
+      if ($rootValue !== '' && $thisValue !== '') {
+        $root->setAttribute($attr, $rootValue.' '.$thisValue);
+        $this->removeAttribute($attr);
+      }
     }
 
     // Transfer all valid attributes to the returned node.

--- a/src/html/XHPHelpers.php
+++ b/src/html/XHPHelpers.php
@@ -9,8 +9,7 @@
  *
  */
 
-interface HasXHPHelpers {
-  require extends :x:composable-element;
+interface HasXHPHelpers extends HasXHPBaseHTMLHelpers, XHPHasTransferAttributes {
 };
 
 /*
@@ -20,61 +19,9 @@ interface HasXHPHelpers {
  * attribute :xhp:html-element;
  */
 trait XHPHelpers implements HasXHPHelpers {
-
   require extends :x:composable-element;
 
-  /*
-   * Appends a string to the "class" attribute (space separated).
-   */
-  public function addClass(string $class): this {
-    try {
-      $current_class = /* UNSAFE_EXPR */ $this->:class;
-      return $this->setAttribute('class', trim($current_class.' '.$class));
-    } catch (XHPInvalidAttributeException $error) {
-      throw new XHPException(
-        'You are trying to add an HTML class to a(n) '.
-        :xhp::class2element(static::class).' element, but it does not support '.
-        'the "class" attribute. The best way to do this is to inherit '.
-        'the HTML attributes from the element your component will render into.',
-      );
-    }
-  }
-
-  /*
-   * Conditionally adds a class to the "class" attribute.
-   */
-  public function conditionClass(bool $cond, string $class): this {
-    return $cond ? $this->addClass($class) : $this;
-  }
-
-  /*
-   * Generates a unique ID (and sets it) on the "id" attribute. A unique ID
-   * will only be generated if one has not already been set.
-   */
-  public function requireUniqueID(): string {
-    $id = /* UNSAFE_EXPR */ $this->:id;
-    if ($id === null || $id === '') {
-      try {
-        $this->setAttribute('id', $id = substr(md5(mt_rand(0, 100000)), 0, 10));
-      } catch (XHPInvalidAttributeException $error) {
-        throw new XHPException(
-          'You are trying to add an HTML id to a(n) '.
-          :xhp::class2element(static::class).' element, but it does not '.
-          'support the "id" attribute. The best way to do this is to inherit '.
-          'the HTML attributes from the element your component will render '.
-          'into.',
-        );
-      }
-    }
-    return (string)$id;
-  }
-
-  /*
-   * Fetches the "id" attribute, will generate a unique value if not set.
-   */
-  final public function getID(): string {
-    return $this->requireUniqueID();
-  }
+  use XHPBaseHTMLHelpers;
 
   /*
    * Copies all attributes that are set on $this and valid on $target to
@@ -187,4 +134,45 @@ trait XHPHelpers implements HasXHPHelpers {
     }
   }
 
+  final public function transferAttributesToRenderedRoot(
+    :x:composable-element $root,
+  ): void {
+    if (:xhp::$ENABLE_VALIDATION && $root instanceof :x:element) {
+      if (!($root instanceof HasXHPHelpers)) {
+        throw new XHPClassException(
+          $this,
+          'compose() must return an :xhp:html-element or :bootstrap:base '.
+          'instance.'
+        );
+      }
+
+      $rootID = $root->getAttribute('id') ?: null;
+      $thisID = $this->getAttribute('id') ?: null;
+
+      if ($rootID && $thisID && $rootID != $thisID) {
+        throw new XHPException(
+          'ID Collision. '.(:xhp::class2element(self::class)).' has an ID '.
+          'of "'.$thisID.'" but it renders into a(n) '.
+          (:xhp::class2element(get_class($root))).
+          ' which has an ID of "'.$rootID.'". The latter will get '.
+          'overwritten (most often unexpectedly). If you are intending for '.
+          'this behavior consider calling $this->removeAttribute(\'id\') '.
+          'before returning your node from compose().'
+        );
+      }
+    }
+    assert($root instanceof HasXHPHelpers);
+
+    $attributes = $this->getAttributes();
+
+    // We want to append classes to the root node, instead of replace them,
+    // so do this attribute manually and then remove it.
+    if (array_key_exists('class', $attributes) && $attributes['class']) {
+      $root->addClass((string) $attributes['class']);
+      $this->removeAttribute('class');
+    }
+
+    // Transfer all valid attributes to the returned node.
+    $this->transferAllAttributes($root);
+  }
 }

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -1,0 +1,87 @@
+<?hh
+
+class :test:no-xhphelpers extends :x:element {
+  use XHPBaseHTMLHelpers;
+  attribute :xhp:html-element;
+
+  protected function render(): XHPRoot {
+    return <div />;
+  }
+}
+
+class :test:xhphelpers extends :x:element {
+  use XHPHelpers;
+  attribute :xhp:html-element;
+
+  protected function render(): XHPRoot {
+    return <div />;
+  }
+}
+
+class :test:async:no-xhphelpers extends :x:element {
+  use XHPAsync;
+  use XHPBaseHTMLHelpers;
+  attribute :xhp:html-element;
+
+  protected async function asyncRender(): Awaitable<XHPRoot> {
+    return <div />;
+  }
+}
+
+class :test:async:xhphelpers extends :x:element {
+  use XHPAsync;
+  use XHPHelpers;
+  attribute :xhp:html-element;
+
+  protected async function asyncRender(): Awaitable<XHPRoot> {
+    return <div />;
+  }
+}
+
+class XHPHelpersTest extends PHPUnit_Framework_TestCase {
+  public function testTransferAttributesWithoutHelpers(): void {
+    $x = <test:no-xhphelpers data-foo="bar" />;
+    $this->assertSame('<div></div>', $x->toString());
+    $this->assertNotEmpty($x->getID());
+    $this->assertSame('<div></div>', $x->toString());
+  }
+
+  public function testTransferAttributesAsyncWithoutHelpers(): void {
+    $x = <test:async:no-xhphelpers data-foo="bar" />;
+    $this->assertSame('<div></div>', $x->toString());
+    $this->assertNotEmpty($x->getID());
+    $this->assertSame('<div></div>', $x->toString());
+  }
+
+  public function testTransferAttributesWithHelpers(): void {
+    $x = <test:xhphelpers data-foo="bar" />;
+    $this->assertSame('<div data-foo="bar"></div>', $x->toString());
+    $this->assertNotEmpty($x->getID());
+    $this->assertSame('<div id="'.$x->getID().'"></div>', $x->toString());
+  }
+
+  public function testTransferAttributesAsyncWithHelpers(): void {
+    $x = <test:async:xhphelpers data-foo="bar" />;
+    $this->assertSame('<div data-foo="bar"></div>', $x->toString());
+    $this->assertNotEmpty($x->getID());
+    $this->assertSame('<div id="'.$x->getID().'"></div>', $x->toString());
+  }
+
+  public function testAddClassWithoutHelpers(): void {
+    $x = <test:no-xhphelpers class="foo" />;
+    $x->addClass("bar");
+    $x->conditionClass(true, "herp");
+    $x->conditionClass(false, "derp");
+    $this->assertSame('foo bar herp', $x->:class);
+    $this->assertSame("<div></div>", $x->toString());
+  }
+
+  public function testAddClassWithHelpers(): void {
+    $x = <test:xhphelpers class="foo" />;
+    $x->addClass("bar");
+    $x->conditionClass(true, "herp");
+    $x->conditionClass(false, "derp");
+    $this->assertSame('foo bar herp', $x->:class);
+    $this->assertSame('<div class="foo bar herp"></div>', $x->toString());
+  }
+}

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -38,6 +38,15 @@ class :test:async:xhphelpers extends :x:element {
   }
 }
 
+class :test:with-class-on-root extends :x:element {
+  use XHPHelpers;
+  attribute :xhp:html-element;
+
+  protected function render(): XHPRoot {
+    return <div class="rootClass" />;
+  }
+}
+
 class XHPHelpersTest extends PHPUnit_Framework_TestCase {
   public function testTransferAttributesWithoutHelpers(): void {
     $x = <test:no-xhphelpers data-foo="bar" />;
@@ -83,5 +92,18 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
     $x->conditionClass(false, "derp");
     $this->assertSame('foo bar herp', $x->:class);
     $this->assertSame('<div class="foo bar herp"></div>', $x->toString());
+  }
+
+  public function testRootClassPreserved(): void {
+    $x = <test:with-class-on-root />;
+    $this->assertSame('<div class="rootClass"></div>', $x->toString());
+  }
+
+  public function testTransferedClassesAppended(): void {
+    $x = <test:with-class-on-root class="extraClass" />;
+    $this->assertSame(
+      '<div class="rootClass extraClass"></div>',
+      $x->toString(),
+    );
   }
 }

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -106,4 +106,9 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
       $x->toString(),
     );
   }
+
+  public function testRootClassesNotOverridenByEmptyString(): void {
+    $x = <test:with-class-on-root class="" />;
+    $this->assertSame('<div class="rootClass"></div>', $x->toString());
+  }
 }


### PR DESCRIPTION
- split out XHPBaseHTMLHelpers to just implement the ID and class helpers
  without transferAttributes
- added tests
- XHPHelpers should probably be renamed to XHPHTMLHelpers in XHP-Lib 3, and
  the bulk of the transfer/copyattribtues functiontionality split to
  XHPTransferAttributes or something like that. Keeping like this for now to
  reduce BC breakage
- Allows implementation of non-HTML helpers; until the above modification happens
  this will involve copypasta, but better than the current situation.
- I /think/ this gets rid of the render()/compose() pattern.

Fixes facebook/xhp-lib#130