### PR TITLE
Refactor __flushRenderedRootElement/__flushElementChildren

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -466,31 +466,8 @@ abstract class :x:composable-element extends :xhp {
       for ($i = 0; $i < $ln; ++$i) {
         $child = $this->children->get($i);
         if ($child instanceof :x:element) {
-          do {
-            assert($child instanceof :x:element);
-            if ($child instanceof XHPAwaitable) {
-              $child = static::__xhpAsyncRender($child)->getWaitHandle();
-            } else {
-              $child = $child->render();
-            }
-            if ($child instanceof WaitHandle) {
-              $childWaitHandles[$i] = $child;
-            } else if ($child instanceof :x:element) {
-              continue;
-            } else if ($child instanceof :x:frag) {
-              $children = $this->children->toValuesArray();
-              array_splice($children, $i, 1, $child->getChildren());
-              $this->children = new Vector($children);
-              $ln = count($this->children);
-              --$i;
-            } else if ($child === null) {
-              $this->children->removeKey($i);
-              $i--;
-            } else {
-              assert($child instanceof XHPChild);
-              $this->children[$i] = $child;
-            }
-          } while ($child instanceof :x:element);
+          $child = $child->__renderAndProcess()->getWaitHandle();
+          $childWaitHandles[$i] = $child;
         }
       }
     } while ($childWaitHandles);

--- a/src/core/Element.php
+++ b/src/core/Element.php
@@ -24,47 +24,43 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
   }
 
   final public async function asyncToString(): Awaitable<string> {
-    if (:xhp::$ENABLE_VALIDATION) {
-      $this->validateChildren();
-    }
     $that = await $this->__flushRenderedRootElement();
     $ret = await $that->asyncToString();
     return $ret;
+  }
+
+  protected async function __renderAndProcess(): Awaitable<XHPRoot> {
+    if (:xhp::$ENABLE_VALIDATION) {
+      $this->validateChildren();
+    }
+
+    if ($this instanceof XHPAwaitable) {
+      $composed = await static::__xhpAsyncRender($this);
+    } else {
+      $composed = $this->render();
+    }
+
+    $composed->__transferContext($this->getAllContexts());
+    if ($this instanceof XHPHasTransferAttributes) {
+      $this->transferAttributesToRenderedRoot($composed);
+    }
+
+    return $composed;
   }
 
   final protected async function __flushRenderedRootElement(
   ): Awaitable<:x:primitive> {
     $that = $this;
     // Flush root elements returned from render() to an :x:primitive
-    do {
-      if (:xhp::$ENABLE_VALIDATION) {
-        $that->validateChildren();
-      }
-      if ($that instanceof XHPAwaitable) {
-        $composed = await static::__xhpAsyncRender($that);
-      } else {
-        invariant(
-          $that instanceof :x:element,
-          "Trying to render something that isn't an element",
-        );
-        $composed = $that->render();
-      }
-      invariant(
-        $composed instanceof :x:composable-element,
-        'Did not get an :x:element from render()',
-      );
-      $composed->__transferContext($that->getAllContexts());
-      if ($that instanceof XHPHasTransferAttributes) {
-        $that->transferAttributesToRenderedRoot($composed);
-      }
-      $that = $composed;
-    } while ($composed instanceof :x:element);
-
-    if (!($composed instanceof :x:primitive)) {
-      // render() must always (eventually) return :x:primitive
-      throw new XHPCoreRenderException($this, $that);
+    while ($that instanceof :x:element) {
+      $that = await $that->__renderAndProcess();
     }
 
-    return $composed;
+    if ($that instanceof :x:primitive) {
+      return $that;
+    }
+
+    // render() must always (eventually) return :x:primitive
+    throw new XHPCoreRenderException($this, $that);
   }
 }

--- a/src/core/XHPRoot.php
+++ b/src/core/XHPRoot.php
@@ -10,4 +10,5 @@
  */
 
 interface XHPRoot extends XHPChild {
+  require extends :x:composable-element;
 }

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -8,6 +8,29 @@ class :async:test extends :x:element {
   }
 }
 
+class :async:par-test extends :x:element {
+  use XHPAsync;
+
+  attribute string label @required;
+
+  public static $log = Vector { };
+
+  protected async function asyncRender(): Awaitable<XHPRoot> {
+    self::$log[] = [$this, 'start render'];
+    await RescheduleWaitHandle::create(
+      RescheduleWaitHandle::QUEUE_DEFAULT,
+      0,
+    );
+    self::$log[] = [$this, 'rescheduled 1'];
+    await RescheduleWaitHandle::create(
+      RescheduleWaitHandle::QUEUE_DEFAULT,
+      0,
+    );
+    self::$log[] = [$this, 'rescheduled 2'];
+    return <div>{$this->:label}</div>;
+  }
+}
+
 class AsyncTest extends PHPUnit_Framework_TestCase {
   public function testDiv() {
     $xhp = <async:test>Herp</async:test>;
@@ -43,5 +66,57 @@ class AsyncTest extends PHPUnit_Framework_TestCase {
   public function testInstanceOfInterface() {
     $xhp = <async:test><b>BE BOLD</b></async:test>;
     $this->assertInstanceOf(XHPAwaitable::class, $xhp);
+  }
+
+  public function testParallelization() {
+    $a = <async:par-test label="a" />;
+    $b = <async:par-test label="b" />;
+    $tree = <async:test>{$a}{$b}</async:test>;
+    $this->assertSame('<div><div>a</div><div>b</div></div>', $tree->toString());
+
+    $log = new Map(:async:par-test::$log);
+    $this->assertSame(6, count($log));
+
+    $max_start = 0;
+    $min_rs1 = 6;
+    $max_rs1 = 0;
+    $min_rs2 = 6;
+    $max_rs2 = 0;
+
+    foreach ($log as $idx => $data) {
+      list($obj, $what) = $data;
+      switch ($what) {
+        case 'start render':
+          $max_start = max($max_start, $idx);
+          break;
+        case 'rescheduled 1':
+          $min_rs1 = min($min_rs1, $idx);
+          $max_rs1 = max($max_rs1, $idx);
+          break;
+        case 'rescheduled 2':
+          $min_rs2 = min($min_rs2, $idx);
+          $max_rs2 = max($max_rs2, $idx);
+          break;
+        default:
+          $this->fail("Invalid action '".$what."'");
+      }
+    }
+
+    $this->assertSame(
+      1,
+      $max_start,
+      'both async children should start before first reschedule resumed',
+    );
+    $this->assertTrue(
+      $min_rs1 > $max_start,
+      'no reschedule wait handles should be complete before all asyncRenders '.
+      'have started',
+    );
+    $this->assertTrue(
+      $min_rs2 > $max_rs1,
+      'the first round of rescheduled should all be queued before any are '.
+      'complete',
+    );
+    $this->assertSame(5, $max_rs2, 'The last event must be a second reschedule');
   }
 }

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -276,4 +276,12 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       </test:needs-comma-category>;
     $this->assertSame('<div></div>', $x->toString());
   }
+
+  /**
+   * @expectedException XHPInvalidChildrenException
+   */
+  public function testNested(): void {
+    $x = <div><test:at-least-one-child /></div>;
+    $x->toString();
+  }
 }

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -14,7 +14,7 @@ class :test:xhphelpers extends :x:element {
   attribute :xhp:html-element;
 
   protected function render(): XHPRoot {
-    return <div />;
+    return <div>{$this->getChildren() }</div>;
   }
 }
 
@@ -110,5 +110,13 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
   public function testRootClassesNotOverridenByEmptyString(): void {
     $x = <test:with-class-on-root class="" />;
     $this->assertSame('<div class="rootClass"></div>', $x->toString());
+  }
+
+  public function testNested(): void {
+    $x =
+      <test:xhphelpers class="herp">
+        <test:xhphelpers class="derp" />
+      </test:xhphelpers>;
+    $this->assertSame('<div class="herp"><div class="derp"></div></div>', $x->toString());
   }
 }


### PR DESCRIPTION
Two commits adding failing tests, 1 commit adding a refactor that simplifies the code and fixes them.

fixes #136
fixes #85