### PR TITLE
Refactor take 2

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -439,73 +439,7 @@ abstract class :x:composable-element extends :xhp {
     }
   }
 
-  final protected async function __flushElementChildren(): Awaitable<void> {
-    // Flush all :xhp elements to x:primitive's
-
-    foreach ($this->children as $child) {
-      if ($child instanceof :x:composable-element) {
-        $child->__transferContext($this->context);
-      }
-    }
-
-    $childWaitHandles = Map{};
-    do {
-      if ($childWaitHandles) {
-        $awaitedChildren = await GenMapWaitHandle::create($childWaitHandles);
-        if ($awaitedChildren) {
-          foreach ($awaitedChildren as $i => $awaitedChild) {
-            $this->children->set($i, $awaitedChild);
-          }
-          // Convert <x:frag>s
-          $this->replaceChildren(<x:frag>{$this->children}</x:frag>);
-          $childWaitHandles = Map{};
-        }
-      }
-
-      $ln = count($this->children);
-      for ($i = 0; $i < $ln; ++$i) {
-        $child = $this->children->get($i);
-        if ($child instanceof :x:element) {
-          do {
-            assert($child instanceof :x:element);
-            if ($child instanceof XHPAwaitable) {
-              $child = static::__xhpAsyncRender($child)->getWaitHandle();
-            } else {
-              $child = $child->render();
-            }
-            if ($child instanceof WaitHandle) {
-              $childWaitHandles[$i] = $child;
-            } else if ($child instanceof :x:element) {
-              continue;
-            } else if ($child instanceof :x:frag) {
-              $children = $this->children->toValuesArray();
-              array_splice($children, $i, 1, $child->getChildren());
-              $this->children = new Vector($children);
-              $ln = count($this->children);
-              --$i;
-            } else if ($child === null) {
-              $this->children->removeKey($i);
-              $i--;
-            } else {
-              assert($child instanceof XHPChild);
-              $this->children[$i] = $child;
-            }
-          } while ($child instanceof :x:element);
-        }
-      }
-    } while ($childWaitHandles);
-
-    $flushWaitHandles = Vector{};
-    foreach ($this->children as $child) {
-      if ($child instanceof :x:primitive) {
-        $flushWaitHandles[] = $child->__flushElementChildren()->getWaitHandle();
-      }
-    }
-
-    if ($flushWaitHandles) {
-      await GenVectorWaitHandle::create($flushWaitHandles);
-    }
-  }
+  abstract protected function __flushSubtree(): Awaitable<:x:primitive>;
 
   /**
    * Defined in elements by the `attribute` keyword. The declaration is simple.

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -18,15 +18,6 @@ abstract class :x:composable-element extends :xhp {
   private Vector<XHPChild> $children = Vector {};
   private Map<string, mixed> $context = Map {};
 
-  // Helper to put all the UNSAFE in one place until facebook/hhvm#4830 is
-  // addressed
-  protected static async function __xhpAsyncRender(
-    XHPAwaitable $child,
-  ): Awaitable<XHPRoot> {
-    // UNSAFE
-    return await $child->asyncRender();
-  }
-
   protected function init(): void {}
 
   /**

--- a/src/core/Element.php
+++ b/src/core/Element.php
@@ -40,7 +40,8 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
     }
 
     if ($this instanceof XHPAwaitable) {
-      $composed = await static::__xhpAsyncRender($this);
+      // UNSAFE - interfaces don't support 'protected': facebook/hhvm#4830
+      $composed = await $this->asyncRender();
     } else {
       $composed = $this->render();
     }

--- a/src/core/Element.php
+++ b/src/core/Element.php
@@ -24,47 +24,48 @@ abstract class :x:element extends :x:composable-element implements XHPRoot {
   }
 
   final public async function asyncToString(): Awaitable<string> {
-    if (:xhp::$ENABLE_VALIDATION) {
-      $this->validateChildren();
-    }
     $that = await $this->__flushRenderedRootElement();
     $ret = await $that->asyncToString();
     return $ret;
+  }
+
+  final protected async function __flushSubtree(): Awaitable<:x:primitive> {
+    $that = await $this->__flushRenderedRootElement();
+    return await $that->__flushSubtree();
+  }
+
+  protected async function __renderAndProcess(): Awaitable<XHPRoot> {
+    if (:xhp::$ENABLE_VALIDATION) {
+      $this->validateChildren();
+    }
+
+    if ($this instanceof XHPAwaitable) {
+      $composed = await static::__xhpAsyncRender($this);
+    } else {
+      $composed = $this->render();
+    }
+
+    $composed->__transferContext($this->getAllContexts());
+    if ($this instanceof XHPHasTransferAttributes) {
+      $this->transferAttributesToRenderedRoot($composed);
+    }
+
+    return $composed;
   }
 
   final protected async function __flushRenderedRootElement(
   ): Awaitable<:x:primitive> {
     $that = $this;
     // Flush root elements returned from render() to an :x:primitive
-    do {
-      if (:xhp::$ENABLE_VALIDATION) {
-        $that->validateChildren();
-      }
-      if ($that instanceof XHPAwaitable) {
-        $composed = await static::__xhpAsyncRender($that);
-      } else {
-        invariant(
-          $that instanceof :x:element,
-          "Trying to render something that isn't an element",
-        );
-        $composed = $that->render();
-      }
-      invariant(
-        $composed instanceof :x:composable-element,
-        'Did not get an :x:element from render()',
-      );
-      $composed->__transferContext($that->getAllContexts());
-      if ($that instanceof XHPHasTransferAttributes) {
-        $that->transferAttributesToRenderedRoot($composed);
-      }
-      $that = $composed;
-    } while ($composed instanceof :x:element);
-
-    if (!($composed instanceof :x:primitive)) {
-      // render() must always (eventually) return :x:primitive
-      throw new XHPCoreRenderException($this, $that);
+    while ($that instanceof :x:element) {
+      $that = await $that->__renderAndProcess();
     }
 
-    return $composed;
+    if ($that instanceof :x:primitive) {
+      return $that;
+    }
+
+    // render() must always (eventually) return :x:primitive
+    throw new XHPCoreRenderException($this, $that);
   }
 }

--- a/src/core/XHPRoot.php
+++ b/src/core/XHPRoot.php
@@ -10,4 +10,5 @@
  */
 
 interface XHPRoot extends XHPChild {
+  require extends :x:composable-element;
 }

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -15,6 +15,11 @@ class BasicsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('<div> Hello, world. </div>', $xhp->toString());
   }
 
+  public function testFragWithString() {
+    $xhp = <x:frag>Derp</x:frag>;
+    $this->assertSame('Derp', $xhp->toString());
+  }
+
   public function testDivWithChild() {
     $xhp = <div><div>Herp</div></div>;
     $this->assertEquals('<div><div>Herp</div></div>', $xhp->toString());

--- a/tests/ChildRuleTest.php
+++ b/tests/ChildRuleTest.php
@@ -276,4 +276,12 @@ class ChildRuleTest extends PHPUnit_Framework_TestCase {
       </test:needs-comma-category>;
     $this->assertSame('<div></div>', $x->toString());
   }
+
+  /**
+   * @expectedException XHPInvalidChildrenException
+   */
+  public function testNested(): void {
+    $x = <div><test:at-least-one-child /></div>;
+    $x->toString();
+  }
 }

--- a/tests/XHPHelpersTest.php
+++ b/tests/XHPHelpersTest.php
@@ -14,7 +14,7 @@ class :test:xhphelpers extends :x:element {
   attribute :xhp:html-element;
 
   protected function render(): XHPRoot {
-    return <div />;
+    return <div>{$this->getChildren() }</div>;
   }
 }
 
@@ -110,5 +110,13 @@ class XHPHelpersTest extends PHPUnit_Framework_TestCase {
   public function testRootClassesNotOverridenByEmptyString(): void {
     $x = <test:with-class-on-root class="" />;
     $this->assertSame('<div class="rootClass"></div>', $x->toString());
+  }
+
+  public function testNested(): void {
+    $x =
+      <test:xhphelpers class="herp">
+        <test:xhphelpers class="derp" />
+      </test:xhphelpers>;
+    $this->assertSame('<div class="herp"><div class="derp"></div></div>', $x->toString());
   }
 }


### PR DESCRIPTION
- all tests pass, including tests added that failed against previous PR
- every element renders itself and it's children
- all child rendering is async
- so, the XHP tree becomes a corresponding async tree

This means that asyncRender() at different depths in the tree can be executing simultaneously.

There shouldn't be much of a performance cost, as HHVM should convert things things
to a StaticWaitHandle when XHPAsync isn't being used.

fixes facebook/xhp-lib#136
fixes facebook/xhp-lib#85