### PR TITLE
Support shapes in XHP Attributes

### DIFF
--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -521,7 +521,7 @@ abstract class :x:composable-element extends :xhp {
         }
         if (enum_exists($class) && $class::isValid($val)) {
           break;
-        }
+        } elseif(is_array($val)) break;
         throw new XHPInvalidAttributeException(
           $this, $class, $attr, $val
         );


### PR DESCRIPTION
Since https://github.com/facebook/hhvm/commit/1af26a6ff11004f1a5e3566c319af9f05e4d3ff0 in HHVM, HHVM validates hack on runtime as well, meaning it would be almost impossible to pass an invalid xhp attribute value.
So we can just skip validation here trusting the typechecker.