### PR TITLE
Mark callable as a FIXME

### DIFF
--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -41,6 +41,7 @@ class :test:default-attributes extends :x:element {
 
 class :test:callable-attribute extends :x:element {
   attribute
+    /* HH_FIXME[2049]: callable is an invalid Hack type */
     callable foo; // unsupported in 2.0+
   protected function render(): XHPRoot {
     $x = $this->getAttribute('foo');


### PR DESCRIPTION
Since `callable` isn't a valid Hack type, get Hack to ignore it. Allows XHP to be included in `assume_php=false` projects.