### PR TITLE
Add "as" attribute to link element

### DIFF
--- a/src/html/tags/l/Link.php
+++ b/src/html/tags/l/Link.php
@@ -11,6 +11,7 @@
 
 class :link extends :xhp:html-singleton {
   attribute
+    Stringish as,
     enum {'anonymous', 'use-credentials'} crossorigin, Stringish href,
     Stringish hreflang, Stringish media, Stringish rel @required, Stringish sizes,
     Stringish type;


### PR DESCRIPTION
Example:

```html
<link rel="preload" href="https://cdn.example.com/resource.js" as="script">
```