### PR TITLE
Implement JsonSerializable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ php:
 install: composer install
 script:
  - hh_client
- - hhvm vendor/bin/phpunit
+ - hhvm vendor/bin/phpunit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+sudo: required
+dist: trusty
+group: edge
+php:
+ - hhvm
+ - hhvm-nightly
+ - hhvm-3.15
+ - hhvm-3.12
+install: composer install
+script:
+ - hh_client
+ - hhvm vendor/bin/phpunit

--- a/src/core/XHP.php
+++ b/src/core/XHP.php
@@ -9,7 +9,7 @@
  *
  */
 
-abstract class :xhp implements XHPChild {
+abstract class :xhp implements XHPChild, JsonSerializable {
   public function __construct(
     KeyedTraversable<string, mixed> $attributes,
     Traversable<XHPChild> $children,
@@ -57,6 +57,10 @@ abstract class :xhp implements XHPChild {
     return $this->toString();
   }
 
+  final public function jsonSerialize(): string {
+    return $this->toString();
+  }
+
   final protected static function renderChild(XHPChild $child): string {
     if ($child instanceof :xhp) {
       return $child->toString();
@@ -65,7 +69,7 @@ abstract class :xhp implements XHPChild {
     } else if ($child instanceof Traversable) {
       throw new XHPRenderArrayException('Can not render traversables!');
     } else {
-      return htmlspecialchars((string)$child);
+      return htmlspecialchars((string) $child);
     }
   }
 

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -46,21 +46,20 @@ class BasicsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testElement2Class(): void {
-    $this->assertSame(
-      :div::class,
-      :xhp::element2class('div'),
-    );
+    $this->assertSame(:div::class, :xhp::element2class('div'));
   }
 
   public function testClass2Element(): void {
-    $this->assertSame(
-      'div',
-      :xhp::class2element(:div::class),
-    );
+    $this->assertSame('div', :xhp::class2element(:div::class));
   }
 
   public function testRendersPrimitive(): void {
     $xhp = <test:renders-primitive />;
     $this->assertSame('<div>123</div>', $xhp->toString());
+  }
+
+  public function testJsonSerialize(): void {
+    $xhp = <div>Hello world.</div>;
+    $this->assertSame('["<div>Hello world.<\/div>"]', json_encode([$xhp]));
   }
 }


### PR DESCRIPTION
Adds a jsonSerialize method to :xhp that returns `toString`.
    
Fixes #164