### PR TITLE
Add hhvm composer example to readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -25,6 +25,10 @@ h1. Installation
   }
 </pre></code>
 
+Run Composer commands using HHVM like so:
+
+bc. $ hhvm $(which composer) install;
+
 h1. Simple Example
 
 bc. <?hh


### PR DESCRIPTION
I was having a hard time realizing that I have to run Composer through hhvm.  Perhaps an example like this in the Readme would have helped.