### PR TITLE
Switch from fredemmott/type-assert to hhvm/type-assert.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["BSD-3-Clause"],
     "require": {
         "hhvm": "~3.12",
-        "fredemmott/type-assert": "^0.2.0 || ^1.0"
+        "hhvm/type-assert": "^0.2.0 || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["BSD-3-Clause"],
     "require": {
         "hhvm": "~3.12",
-        "hhvm/type-assert": "^0.2.0 || ^1.0"
+        "hhvm/type-assert": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "46c4bdeec3a0ee232610b4aee75d7733",
+    "content-hash": "60a2e3fa336131af85fb283c344dc3f3",
     "packages": [
         {
             "name": "hhvm/type-assert",
-            "version": "v1.1.1",
+            "version": "v2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/type-assert.git",
-                "reference": "a370a1b0f057f1fc3c000fa7c79b2439448c0a1b"
+                "reference": "fcd2cdc238302242b0da207fe395d6f7f2e8a2a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/a370a1b0f057f1fc3c000fa7c79b2439448c0a1b",
-                "reference": "a370a1b0f057f1fc3c000fa7c79b2439448c0a1b",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/fcd2cdc238302242b0da207fe395d6f7f2e8a2a6",
+                "reference": "fcd2cdc238302242b0da207fe395d6f7f2e8a2a6",
                 "shasum": ""
             },
             "require": {
@@ -34,15 +34,12 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
             "description": "Convert untyped data to typed data",
             "keywords": [
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2017-08-14T23:59:57+00:00"
+            "time": "2017-08-29T21:00:54+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "26d43651bf5d16e274520150e42e4f17",
+    "content-hash": "46c4bdeec3a0ee232610b4aee75d7733",
     "packages": [
         {
-            "name": "fredemmott/type-assert",
-            "version": "v1.1",
+            "name": "hhvm/type-assert",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fredemmott/type-assert.git",
-                "reference": "38460b438ca85701585abe471d944c678d242847"
+                "url": "https://github.com/hhvm/type-assert.git",
+                "reference": "a370a1b0f057f1fc3c000fa7c79b2439448c0a1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fredemmott/type-assert/zipball/38460b438ca85701585abe471d944c678d242847",
-                "reference": "38460b438ca85701585abe471d944c678d242847",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/a370a1b0f057f1fc3c000fa7c79b2439448c0a1b",
+                "reference": "a370a1b0f057f1fc3c000fa7c79b2439448c0a1b",
                 "shasum": ""
             },
             "require": {
@@ -42,7 +42,7 @@
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2017-02-15T02:26:23+00:00"
+            "time": "2017-08-14T23:59:57+00:00"
         }
     ],
     "packages-dev": [

--- a/src/core/ComposableElement.php
+++ b/src/core/ComposableElement.php
@@ -9,8 +9,8 @@
  *
  */
 
-use FredEmmott\TypeAssert\IncorrectTypeException;
-use FredEmmott\TypeAssert\TypeAssert;
+use Facebook\TypeAssert\IncorrectTypeException;
+use Facebook\TypeAssert\TypeAssert;
 
 abstract class :x:composable-element extends :xhp {
   private Map<string, mixed> $attributes = Map {};


### PR DESCRIPTION
Seeing composer complain about fredemmott/type-assert being abandoned is a bit annoying. I didn't switch to type-assert 2.0 (i.e. change namespaces) because that seems like a bigger deal, but happy to do it if that's considered blocking.